### PR TITLE
feat(docs): add code highlighting using pymdownx extension (#4)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,22 +1,31 @@
 site_name: Flamingo Documentations
+repo_url: https://github.com/i-love-flamingo/flamingo
+repo_name: flamingo
 extra:
   logo: assets/flamingo-icon.svg
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/i-love-flamingo/flamingo
 extra_css:
   - stylesheets/ci.css
 markdown_extensions:
   - admonition
-  - codehilite:
-      guess_lang: false
+  - pymdownx.highlight
+  - pymdownx.superfences
   - toc:
       permalink: true
-  - extra
   - footnotes
   - abbr
 use_directory_urls: false
 theme:
   name: 'material'
+  features:
+    - content.code.copy
+    - content.stats
   favicon: assets/flamingo_head_black.png
   logo: assets/flamingo-icon-white.svg
+  icon:
+    repo: fontawesome/brands/github
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"


### PR DESCRIPTION
From what I could tell, under the `markdown_extensions` , the `extra` was causing the issue. I have made some QoL changes (adding github on navbar, copy option on the snippets) which required me to bump down the version abit. Addressing #4. 

One more thing- I could have enabled linenums 
```yaml
  - pymdownx.highlight:
      linenums: true
```
and this would've globally enabled line numbers on each code block. But since lines are only refferenced on the hello world example, i believe it would be more fitting to just enable the line numbering (```go linenums="1") directly in the core repositry. I am willing to make a PR for this as well over there, if this gets approved.